### PR TITLE
Added the link `as`, a11y slightly, added demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ Simple.css is a classless CSS template that allows you to make a good looking we
 **Find out more at [https://simplecss.org](https://simplecss.org).**
 
 ![Screenshot of Simple.css](screenshot.png)
+
+## Supported Browsers
+
+Any evergreen browser > IE11

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,365 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Demo | Simple.css {}</title>
+  <meta name="description" content="A showcase of Simple.css formatting in action and how to use it." />
+  <link rel="stylesheet" href="./simple.css">
+</head>
+<body>
+
+<header>
+  <h1>Demo</h1>
+  <p>A showcase of Simple.css formatting in action and how to use it.</p>
+
+  <nav>
+
+    <a href="https://simplecss.org/">Home</a>
+
+    <a href="https://simplecss.org/getting-started">Getting Started</a>
+
+    <a href="/">Demo</a>
+
+    <a href="https://github.com/kevquirk/simple.css">Github</a>
+
+  </nav>
+
+</header>
+
+<main>
+
+  <p>This page is a demonstration of the elements that can be formatted using Simple.css. Each section includes a code block on how to include it in your site’s design.</p>
+
+  <p>This may be a little basic for some people, but I wanted to barrier for entry to be as low as possible for this project.</p>
+
+  <h2 id="basic-typography">Basic Typography</h2>
+
+  <p>All the typography of Simple.css uses <code class="language-plaintext highlighter-rouge">rem</code> for sizing. This means that accessibility is maintained for those who change their browser font size. The <code class="language-plaintext highlighter-rouge">body</code> element has a size of <code class="language-plaintext highlighter-rouge">1.15rem</code>  which makes all the standard font sizes slightly larger. This equates to <code class="language-plaintext highlighter-rouge">18.4px</code> for paragraph text, instead of the standard <code class="language-plaintext highlighter-rouge">16px</code>.</p>
+
+  <p>The <code class="language-plaintext highlighter-rouge">h2</code> and <code class="language-plaintext highlighter-rouge">h3</code> elements also have an increased top margin of <code class="language-plaintext highlighter-rouge">3rem</code> in order to break blocks of text up better.</p>
+
+  <h1 id="heading-1-225rem">Heading 1 <code class="language-plaintext highlighter-rouge">2.25rem</code></h1>
+
+  <h2 id="heading-2-185rem">Heading 2 <code class="language-plaintext highlighter-rouge">1.85rem</code></h2>
+
+  <h3 id="heading-3-155rem">Heading 3 <code class="language-plaintext highlighter-rouge">1.55rem</code></h3>
+
+  <h4 id="heading-4-125rem">Heading 4 <code class="language-plaintext highlighter-rouge">1.25rem</code></h4>
+
+  <h5 id="heading-5-115rem">Heading 5 <code class="language-plaintext highlighter-rouge">1.15rem</code></h5>
+
+  <h6 id="heading-6-9rem">Heading 6 <code class="language-plaintext highlighter-rouge">.9rem</code></h6>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;h2&gt;This is a H2 header&lt;h2&gt;
+
+&lt;p&gt;This is some paragraph text.&lt;/p&gt;
+</code></pre></div></div>
+
+  <h3 id="links--buttons">Links &amp; Buttons</h3>
+
+  <p>Links are formatted very simply on Simple.css (shock horror). They use the <code class="language-plaintext highlighter-rouge">accent</code> CSS variable and are underlined. There is a <code class="language-plaintext highlighter-rouge">:hover</code> effect that removes the underline. Here is an <a href="">example link</a>.</p>
+
+  <p>Buttons use the same <code class="language-plaintext highlighter-rouge">accent</code> CSS variable for their colour. When hovering, there is an opacity effect.</p>
+
+  <p><button>I’m a button</button></p>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;a href="https://example.com"&gt;This is a hyperlink&lt;/a&gt;
+
+&lt;button&gt;I'm a button&lt;/button&gt;
+</code></pre></div></div>
+
+  <p>Links may also be styled as buttons using the <code class="language-plaintext highlighter-rouge">as</code> attribute. This maintains accessibility with the anchor tag while allowing for this common styling practice.</p>
+
+  <p><a href="" as="button">Link as Button</a></p>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;a href="https://example.com" as="button"&gt;Link as Button&lt;/a&gt;
+</code></pre></div></div>
+
+  <h2 id="other-typography-elements">Other typography elements</h2>
+
+  <p>There are a number of other typography elements that you can use with Simple.css. Some of the common ones are:</p>
+
+  <ul>
+    <li>All the standard stuff, like <strong>bold</strong>, <em>italic</em> and <u>underlined</u> text.</li>
+    <li><mark>Highlighting text</mark> using the <code class="language-plaintext highlighter-rouge">mark</code> element.</li>
+    <li>Adding <code class="language-plaintext highlighter-rouge">inline code</code> using the <code class="language-plaintext highlighter-rouge">code</code> element.</li>
+    <li>Displaying keyboard commands like <kbd>ALT+F4</kbd> using the <code class="language-plaintext highlighter-rouge">kbd</code> element.</li>
+  </ul>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;b&gt;Bold text&lt;/b&gt;
+&lt;i&gt;Italic text&lt;/i&gt;
+&lt;u&gt;Underlined text&lt;/u&gt;
+&lt;mark&gt;Highlighted text&lt;/mark&gt;
+&lt;code&gt;Inline code&lt;/code&gt;
+&lt;kbd&gt;Alt+F4&lt;/kbd&gt;
+</code></pre></div></div>
+
+  <h3 id="lists">Lists</h3>
+
+  <p>We all love a good list, right? I know my wife does!</p>
+
+  <ul>
+    <li>Item 1</li>
+    <li>Item 2</li>
+    <li>Item 3</li>
+  </ul>
+
+  <ol>
+    <li>Do this thing</li>
+    <li>Do that thing</li>
+    <li>Do the other thing</li>
+  </ol>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code># Bulleted list
+&lt;ul&gt;
+  &lt;li&gt;Item 1&lt;/li&gt;
+  &lt;li&gt;Item 2&lt;/li&gt;
+  &lt;li&gt;Item 3&lt;/li&gt;
+&lt;/ul&gt;
+
+# Numbered list
+&lt;ol&gt;
+  &lt;li&gt;Do this thing&lt;/li&gt;
+  &lt;li&gt;Do that thing&lt;/li&gt;
+  &lt;li&gt;Do the other thing&lt;/li&gt;
+&lt;/ol&gt;
+</code></pre></div></div>
+  <h3 id="blockquotes">Blockquotes</h3>
+
+  <p>Sometimes you may want to quote someone else in your HTML. For this we use the <code class="language-plaintext highlighter-rouge">blockquote</code> element. Here’s what a quote looks like with Simple.css:</p>
+
+  <blockquote>
+    <p>Friends don’t spy; true friendship is about privacy, too.</p>
+
+    <p><cite>– Stephen King</cite></p>
+  </blockquote>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;blockquote&gt;
+  &lt;p&gt;Friends don’t spy; true friendship is about privacy, too.&lt;/p&gt;
+  &lt;p&gt;&lt;cite&gt;– Stephen King&lt;/cite&gt;&lt;/p&gt;
+&lt;/blockquote&gt;
+</code></pre></div></div>
+
+  <h3 id="code-blocks">Code blocks</h3>
+
+  <p>Code blocks are different from the inline <code class="language-plaintext highlighter-rouge">code</code> element. Code blocks are used when you want to display a block of code, like this:</p>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>body {
+  color: var(--text);
+  background: var(--bg);
+  font-size: 1.15rem;
+  line-height: 1.5;
+  margin: 0;
+}
+</code></pre></div></div>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;pre&gt;
+&lt;code&gt;
+  body {
+    color: var(--text);
+    background: var(--bg);
+    font-size: 1.15rem;
+    line-height: 1.5;
+    margin: 0;
+  }
+&lt;/code&gt;
+&lt;/pre&gt;
+</code></pre></div></div>
+  <h2 id="navigation">Navigation</h2>
+
+  <p>The <code class="language-plaintext highlighter-rouge">nav</code> menu is deliberately designed to be extremely simple so that you can improve on it as you see fit. Or, just leave it as is to have a good looking, functional navigation menu.</p>
+
+  <p>There’s no JavaScript of checkbox CSS hacks here. It’s just a collection of simple “buttons” that wrap to the given width of the page:</p>
+
+  <nav>
+    <a href="">Home</a>
+    <a href="">About</a>
+    <a href="">Blog</a>
+    <a href="">Notes</a>
+    <a href="">Guestbook</a>
+    <a href="">Contact</a>
+    <a href="">Link 1</a>
+    <a href="">Link 2</a>
+    <a href="">Link 3</a>
+  </nav>
+
+  <p>To add a <code class="language-plaintext highlighter-rouge">nav</code> menu, just add the following to the <code class="language-plaintext highlighter-rouge">&lt;header&gt;</code> section of your site:</p>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;nav&gt;
+  &lt;a href=""&gt;Home&lt;/a&gt;
+  &lt;a href=""&gt;About&lt;/a&gt;
+  &lt;a href=""&gt;Blog&lt;/a&gt;
+  &lt;a href=""&gt;Notes&lt;/a&gt;
+  &lt;a href=""&gt;Guestbook&lt;/a&gt;
+  &lt;a href=""&gt;Contact&lt;/a&gt;
+&lt;/nav&gt;
+</code></pre></div></div>
+
+  <h2 id="images">Images</h2>
+
+  <p>In Simple.css, images within the <code class="language-plaintext highlighter-rouge">main</code> element are always full width and have rounded edges to them. The <code class="language-plaintext highlighter-rouge">figcaption</code> element is also formatted in Simple.css. Here are examples of images with and without a caption:</p>
+
+  <p><img src="./screenshot.png" alt="Screenshot of demo" /></p>
+
+  <figure>
+    <img alt="Screenshot of the demo" src="./screenshot.png" />
+    <figcaption>The Screenshot</figcaption>
+  </figure>
+
+  <h2 id="accordions">Accordions</h2>
+
+  <p>Accordions are cool to play with. They’re especially useful when it comes to things like FAQ pages. Many people invoke JavaScript, or <code class="language-plaintext highlighter-rouge">div</code> for life when they use accordions. I don’t really understand why that is what it’s available in plain old HTML:</p>
+
+  <details>
+    <summary>Spoiler alert!</summary>
+    <p>You smell. 🙂</p>
+  </details>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;details&gt;
+  &lt;summary&gt;Spoiler alert!&lt;/summary&gt;
+  &lt;p&gt;You smell. 🙂&lt;/p&gt;
+&lt;/details&gt;
+</code></pre></div></div>
+
+  <h2 id="tables">Tables</h2>
+
+  <p>Like lists, sometimes you may need to add a table to your webpage. In Simple.css tables automatically highlight every other row to make reading easier. Table header text is also bold. Here’s what they look like:</p>
+
+  <table>
+    <thead>
+    <tr>
+      <th>Name</th>
+      <th>Number</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Jackie</td>
+      <td>012345</td>
+    </tr>
+    <tr>
+      <td>Lucy</td>
+      <td>112346</td>
+    </tr>
+    <tr>
+      <td>David</td>
+      <td>493029</td>
+    </tr>
+    <tr>
+      <td>Kerry</td>
+      <td>395499</td>
+    </tr>
+    <tr>
+      <td>Steve</td>
+      <td>002458</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <div class="language-plaintext highlighter-rouge"><div class="highlight"><pre class="highlight"><code>&lt;table&gt;
+  &lt;thead&gt;
+    &lt;tr&gt;
+      &lt;th&gt;Name&lt;/th&gt;
+      &lt;th&gt;Number&lt;/th&gt;
+    &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tbody&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Jackie&lt;/td&gt;
+      &lt;td&gt;012345&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Lucy&lt;/td&gt;
+      &lt;td&gt;112346&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td&gt;David&lt;/td&gt;
+      &lt;td&gt;493029&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Kerry&lt;/td&gt;
+      &lt;td&gt;395499&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Steve&lt;/td&gt;
+      &lt;td&gt;002458&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
+&lt;/table&gt;
+</code></pre></div></div>
+
+  <h2 id="forms">Forms</h2>
+
+  <p>Forms are useful for all kinds of things on webpages. Contact forms, newsletter sign ups etc. Forms also look pretty good on Simple.css:</p>
+
+  <form>
+    <p><strong>This is just a test form. It doesn't do anything.</strong></p>
+    <p>
+      <label for="given">First name</label><br />
+      <input id="given" type="text" name="first_name" />
+    </p>
+    <p>
+      <label for="sur">Surname</label><br />
+      <input id="sur" type="text" name="surname" />
+    </p>
+    <p>
+      <label for="email">Email</label><br />
+      <input id="email" type="email" name="email" required="" />
+    </p>
+    <p>
+      <label for="textarea">Message</label><br />
+      <textarea id="textarea" rows="6"></textarea>
+    </p>
+    <p>
+      <label>
+        <input type="checkbox" id="checkbox" value="terms" />
+        I agree to the <a href="#">terms and conditions</a>
+      </label>
+    </p>
+
+    <button>Send</button>
+    <button type="reset">Reset</button>
+    <button disabled="disabled">Disabled</button>
+
+
+    <pre><code> &lt;form&gt;
+  &lt;p&gt;&lt;strong&gt;This is just a test form. It doesn't do anything.&lt;/strong&gt;&lt;/p&gt;
+  &lt;p&gt;
+    &lt;label&gt;First name&lt;/label&gt;&lt;br&gt;
+    &lt;input type="text" name="first_name"&gt;
+  &lt;/p&gt;
+  &lt;p&gt;
+    &lt;label&gt;Surname&lt;/label&gt;&lt;br&gt;
+    &lt;input type="text" name="surname"&gt;
+  &lt;/p&gt;
+  &lt;p&gt;
+    &lt;label&gt;Email&lt;/label&gt;&lt;br&gt;
+    &lt;input type="email" name="email" required=""&gt;
+  &lt;/p&gt;
+  &lt;p&gt;
+    &lt;label&gt;Message&lt;/label&gt;&lt;br&gt;
+    &lt;textarea&gt;&lt;/textarea&gt;
+  &lt;/p&gt;
+  &lt;p&gt;
+    &lt;label&gt;
+    &lt;input type="checkbox" value="terms"&gt;
+    I agree to the &lt;a href="#"&gt;terms and conditions&lt;/a&gt;
+    &lt;/label&gt;
+  &lt;/p&gt;
+  &lt;button&gt;Send&lt;/button&gt;
+  &lt;button type="reset"&gt;Reset&lt;/button&gt;
+  &lt;button disabled="disabled"&gt;Disabled&lt;/button&gt;
+  &lt;/form&gt;</code>
+  </pre>
+  </form>
+
+
+</main>
+
+<footer>
+  <p>Simple.css was created by <a href="https://kevq.uk">Kev Quirk</a> and is licensed under the MIT license.</p>
+</footer>
+
+</body>
+</html>

--- a/simple.css
+++ b/simple.css
@@ -37,6 +37,7 @@
 * {
   /* Set the font globally */
   font-family: var(--sans-font);
+  box-sizing: border-box;
 }
 
 /* Make the body a nice central block */
@@ -152,6 +153,7 @@ a:hover {
 
 a button,
 button,
+a[as=button],
 input[type="submit"],
 input[type="reset"],
 input[type="button"] {
@@ -163,10 +165,15 @@ input[type="button"] {
   padding: .7rem .9rem;
   margin: .5rem 0;
   transition: .4s;
+  text-decoration: none;
+  display: inline-block;
+  cursor: pointer;
+  line-height: normal;
 }
 
 a button[disabled],
 button[disabled],
+a[as=button][disabled],
 input[type="submit"][disabled],
 input[type="reset"][disabled],
 input[type="button"][disabled] {
@@ -177,6 +184,7 @@ input[type="button"][disabled] {
 
 button:focus,
 button:enabled:hover,
+a[as=button]:hover,
 input[type="submit"]:focus,
 input[type="submit"]:enabled:hover,
 input[type="reset"]:focus,


### PR DESCRIPTION
Let me know if you want to break this up, this is just a series of things I added before I attempted to use this on some of my more simple sites.  I'm also fine if you think this is beyond what your initial vision was.

**Link with "as":** Added the ability for a link to use `as` attribute to look like a button.  I know this is starting to stretch the idea of what this framework is. "You can say it's classless if all you do is add fancy attributes".  I could have swore you had something in here where you nested a <button> inside an <a> tag and had a note that it's not valid HTML.

I've had to focus on a11y and I still really enjoy this library so I am proposing adding a very very simple addition to the `<a>` tag to allow it to look like the button.  I wouldn't want this to spiral out of control however.  It's just a way to re-use the styles that already exist for buttons but apply to a link which is done quite a bit.

**Readme**: Added supported browsers as the CSS variables do not work with IE11 out of the box (yes, it sucks I still have to support that thing).

**Added the demo html page.**  I just copied it from your website and adjusted a few things so it would appear.  It's not needed but thought it would make building/testing the CSS slightly easier.