### PR TITLE
Fix name of `-apple-system`

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -2,7 +2,7 @@
 :root {
 
   /* Set sans-serif & mono fonts */
-  --sans-font: apple-system, BlinkMacSystemFont, avenir next, avenir, "Nimbus Sans L", roboto, noto, segoe ui, arial, helvetica, helvetica neue, sans-serif;
+  --sans-font: -apple-system, BlinkMacSystemFont, avenir next, avenir, "Nimbus Sans L", roboto, noto, segoe ui, arial, helvetica, helvetica neue, sans-serif;
   --mono-font: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
 
   /* Default (light) theme */


### PR DESCRIPTION
The name of the system font on MacOs is actually `-apple-system`. See also: https://css-tricks.com/snippets/css/system-font-stack/