### PR TITLE
Updating Font stack

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -2,8 +2,9 @@
 :root {
 
   /* Set sans-serif & mono fonts */
-  --sans-font: -apple-system, BlinkMacSystemFont, avenir next, avenir, "Nimbus Sans L", roboto, noto, segoe ui, arial, helvetica, helvetica neue, sans-serif;
-  --mono-font: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  --sans-font: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Nimbus Sans L", Roboto, Noto, "Segoe UI", Arial, Helvetica, "Helvetica Neue", sans-serif;
+  --mono-font: Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+
 
   /* Default (light) theme */
   --bg: #fff;

--- a/simple.css
+++ b/simple.css
@@ -5,7 +5,6 @@
   --sans-font: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Nimbus Sans L", Roboto, Noto, "Segoe UI", Arial, Helvetica, "Helvetica Neue", sans-serif;
   --mono-font: Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
 
-
   /* Default (light) theme */
   --bg: #fff;
   --accent-bg: #F5F7FF;


### PR DESCRIPTION
As mentioned in the other PR, this update fixes capitalisation of the fonts (and adds `Menlo`, which ships with MacOS by default, and is objectively less ugly than `Monaco`. ;-) )