### PR TITLE
Updating `kbd`, `mark`, `code` and `pre`

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -23,6 +23,8 @@
   --accent: #0D47A1;
   --accent-light: #90CAF9;
   --code: #D81B60;
+  --preformatted: #666;
+  --marked: #FDB833;	
 }
 
 /* Dark theme */
@@ -323,8 +325,9 @@ hr {
 }
 
 mark {
-	padding: 3px 6px;
-	background: var(--accent-light);
+    padding: 2px 5px;
+    border-radius: 4px;
+    background: var(--marked);
 }
 
 main img {
@@ -362,24 +365,27 @@ code,
 pre,
 kbd,
 samp {
-	font-family: var(--mono-font);
-  color: var(--code);
+    font-size: 1.0rem;
+    font-family: var(--mono-font);
+    color: var(--code);
 }
 
 kbd {
-  border: 1px solid var(--code);
-	border-bottom: 3px solid var(--code);
-  border-radius: 5px;
-  padding: .1rem;
+    color: var(--preformatted);
+    border: 1px solid var(--preformatted);
+    border-bottom: 3px solid var(--preformatted);
+    border-radius: 5px;
+    padding: .1rem;
 }
 
 pre {
-	padding: 1rem 1.4rem;
-	max-width: 100%;
-	overflow: auto;
-  background: var(--accent-bg);
-  border: 1px solid var(--border);
-  border-radius: 5px;
+    padding: 1rem 1.4rem;
+    max-width: 100%;
+    overflow: auto;
+    color: var(--preformatted);
+    background: var(--accent-bg);
+    border: 1px solid var(--border);
+    border-radius: 5px;
 }
 
 /* Fix embedded code within pre */

--- a/simple.css
+++ b/simple.css
@@ -39,7 +39,6 @@
     --accent-light: #FFECB3;
     --code: #F06292;
     --preformatted: #CCC;
-    --marked: #7A6C28;
   }
 
   img {
@@ -330,7 +329,6 @@ mark {
     padding: 2px 5px;
     border-radius: 4px;
     background: var(--marked);
-    color: var(--text);
 }
 
 main img {

--- a/simple.css
+++ b/simple.css
@@ -23,8 +23,8 @@
   --accent: #0D47A1;
   --accent-light: #90CAF9;
   --code: #D81B60;
-  --preformatted: #666;
-  --marked: #FDB833;	
+  --preformatted: #444;
+  --marked: #FFDD33;
 }
 
 /* Dark theme */
@@ -38,6 +38,8 @@
     --accent: #FFB300;
     --accent-light: #FFECB3;
     --code: #F06292;
+    --preformatted: #CCC;
+    --marked: #7A6C28;
   }
 
   img {
@@ -328,6 +330,7 @@ mark {
     padding: 2px 5px;
     border-radius: 4px;
     background: var(--marked);
+    color: var(--text);
 }
 
 main img {
@@ -365,7 +368,7 @@ code,
 pre,
 kbd,
 samp {
-    font-size: 1.0rem;
+    font-size: 1.075rem;
     font-family: var(--mono-font);
     color: var(--code);
 }
@@ -390,7 +393,7 @@ pre {
 
 /* Fix embedded code within pre */
 pre code {
-    color: var(--text);
+    color: var(--preformatted);
     background: none;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
I've changed these four HTML tags a tiny bit. A monospaced font is optically larger at the same point size, because on average the letters are much wider. This PR compensates that by making monospaced tags slightly smaller. 

After:

![Screenshot 2021-01-20 at 15 39 02](https://user-images.githubusercontent.com/1833361/105189897-bf8cc480-5b35-11eb-9c63-50e894d3a3fa.png)


Before: 

![Screenshot 2021-01-20 at 15 39 38](https://user-images.githubusercontent.com/1833361/105189907-c3204b80-5b35-11eb-8c32-bd32edebe0d7.png)


I've noticed the indentation of the CSS is all over the place if you're not using an IDE that 'hides' that from you: '2 spaces', '4 spaces' and '1 tab' are used together. After this one is merged in, I'd like to make a PR to fix the formatting, if that's OK with you. It'll be a large delta, without functional changes. 

![Screenshot 2021-01-20 at 15 34 26](https://user-images.githubusercontent.com/1833361/105190243-16929980-5b36-11eb-9bb9-bc016f3841a9.png)
