### PR TITLE
Update package.json to match npm name 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "simplecss",
+  "name": "simpledotcss",
   "version": "1.0.0",
   "description": "Simple.css is a classless CSS template that allows you to make a good looking website really quickly.",
   "main": "simple.css",


### PR DESCRIPTION
Simple.css is now on NPM: https://www.npmjs.com/package/simpledotcss

Unfortunately the original name was too similar to another package name so I published it as simpledotcss. This PR updates package.json to fit this. 