### PR TITLE
Semi-colon missing in `table`

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -263,8 +263,8 @@ details[open]>*:last-child {
 /* Format tables */
 table {
 	border-collapse: collapse;
-	width: 100%
-  margin: 1.5rem 0;
+	width: 100%;
+  	margin: 1.5rem 0;
 }
 
 td,


### PR DESCRIPTION
Just noticed this a couple times when I copy/paste the non-minified version.