### PR TITLE
Header padding overflows viewport

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -80,6 +80,7 @@ header {
   padding: 2rem .5rem;
   width: 100vw;
   position: relative;
+  box-sizing: border-box;
   left: 50%;
   right: 50%;
   margin-left: -50vw;


### PR DESCRIPTION
Header content takes `100vw` leaving no space for `padding: 2rem .5rem;` that causes header overflow and horizontal scrollbar on mobile devices. Changing to `box-sizing: border-box;` makes content+padding fit the viewport width instead of just the content.
## Before
![before](https://user-images.githubusercontent.com/30303575/118398730-a074ee00-b662-11eb-94a5-a86a59763394.png)
## After
![after](https://user-images.githubusercontent.com/30303575/118398746-aec30a00-b662-11eb-9b4e-64273e45454c.png)