### PR TITLE
Move padding to `summary` for larger tap target

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -237,7 +237,6 @@ input[type="radio"]:enabled:hover{
 
 /* Format the expanding box */
 details {
-  --details-padding: .6rem 1rem;
   background: var(--accent-bg);
   border: 1px solid var(--border);
   border-radius: 5px;
@@ -247,12 +246,11 @@ details {
 summary {
   cursor: pointer;
   font-weight: bold;
-  padding: var(--details-padding);
+  padding: .6rem 1rem;
 }
 
 details[open] {
-  padding-bottom: .75rem;
-  padding: var(--details-padding);
+  padding: .6rem 1rem .75rem 1rem;
 }
 
 details[open] summary {

--- a/simple.css
+++ b/simple.css
@@ -237,7 +237,7 @@ input[type="radio"]:enabled:hover{
 
 /* Format the expanding box */
 details {
-  padding: .6rem 1rem;
+  --details-padding: .6rem 1rem;
   background: var(--accent-bg);
   border: 1px solid var(--border);
   border-radius: 5px;
@@ -247,14 +247,17 @@ details {
 summary {
   cursor: pointer;
   font-weight: bold;
+  padding: var(--details-padding);
 }
 
 details[open] {
   padding-bottom: .75rem;
+  padding: var(--details-padding);
 }
 
 details[open] summary {
   margin-bottom: .5rem;
+  padding: 0;
 }
 
 details[open]>*:last-child {


### PR DESCRIPTION
When `details` is closed, the padding on this element makes the box larger than the tap target, since you can only click on `summary` itself. By moving the padding to `summary` when `details` is collapsed, the tap target takes up the entire visual box. Then it can be moved back to `details` when expanded to keep padding around the contents.

**Before:**
![image](https://user-images.githubusercontent.com/17771229/121717625-3cddb500-ca96-11eb-82eb-d6b49d32843c.png)
(blue above is the tap target, so clicking on the padded area of `details` does nothing, even though there's no visual distinction)

**After:**
![image](https://user-images.githubusercontent.com/17771229/121717320-e5d7e000-ca95-11eb-8853-4b422a047c55.png)
{entire box is now a tap target, with padding applied to `summary` element when collapsed)

I suppose it's also possible to use `padding: unset` or similar for `details[open]` if you wanted to keep it more general than `padding: 0;`. Also there are other ways to handle this in terms of CSS attribute selectors I'm sure but this is a start.

Love this library - I recognize a lot has gone into it. Thanks for maintaining!