### PR TITLE
Fix `simple.css` linting errors

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -1,8 +1,9 @@
 /* Set the global variables for everything. Change these to use your own fonts and colours. */
 :root {
-
   /* Set sans-serif & mono fonts */
-  --sans-font: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, "Nimbus Sans L", Roboto, Noto, "Segoe UI", Arial, Helvetica, "Helvetica Neue", sans-serif;
+  --sans-font: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir,
+    "Nimbus Sans L", Roboto, Noto, "Segoe UI", Arial, Helvetica,
+    "Helvetica Neue", sans-serif;
   --mono-font: Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
 
   /* Body font size. By default, effectively 18.4px, based on 16px as 'root em' */
@@ -15,36 +16,37 @@
   --line-height: 1.618;
 
   /* Default (light) theme */
-  --bg: #FFF;
-  --accent-bg: #F5F7FF;
+  --bg: #fff;
+  --accent-bg: #f5f7ff;
   --text: #212121;
   --text-light: #585858;
-  --border: #D8DAE1;
-  --accent: #0D47A1;
-  --accent-light: #90CAF9;
-  --code: #D81B60;
+  --border: #d8dae1;
+  --accent: #0d47a1;
+  --accent-light: #90caf9;
+  --code: #d81b60;
   --preformatted: #444;
-  --marked: #FFDD33;
-  --disabled: #EFEFEF;
+  --marked: #ffdd33;
+  --disabled: #efefef;
 }
 
 /* Dark theme */
 @media (prefers-color-scheme: dark) {
   :root {
     --bg: #212121;
-    --accent-bg: #2B2B2B;
-    --text: #DCDCDC;
-    --text-light: #ABABAB;
+    --accent-bg: #2b2b2b;
+    --text: #dcdcdc;
+    --text-light: #ababab;
     --border: #666;
-    --accent: #FFB300;
-    --accent-light: #FFECB3;
-    --code: #F06292;
-    --preformatted: #CCC;
+    --accent: #ffb300;
+    --accent-light: #ffecb3;
+    --code: #f06292;
+    --preformatted: #ccc;
     --disabled: #111;
   }
 
-  img, video {
-    opacity: .6;
+  img,
+  video {
+    opacity: 0.6;
   }
 }
 
@@ -65,7 +67,7 @@ body {
   flex: 1;
   margin: 0 auto;
   max-width: 45rem;
-  padding: 0 .5rem;
+  padding: 0 0.5rem;
   overflow-x: hidden;
   word-break: break-word;
   overflow-wrap: break-word;
@@ -76,7 +78,7 @@ header {
   background: var(--accent-bg);
   border-bottom: 1px solid var(--border);
   text-align: center;
-  padding: 2rem .5rem;
+  padding: 2rem 0.5rem;
   width: 100vw;
   position: relative;
   box-sizing: border-box;
@@ -86,7 +88,6 @@ header {
   margin-right: -50vw;
 }
 
-
 /* Remove margins for header text */
 header h1,
 header p {
@@ -94,7 +95,9 @@ header p {
 }
 
 /* Fix line height when title wraps */
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   line-height: 1.1;
 }
 
@@ -111,9 +114,9 @@ nav a {
   border-radius: 5px;
   color: var(--text) !important;
   display: inline-block;
-  padding: .1rem 1rem;
+  padding: 0.1rem 1rem;
   text-decoration: none;
-  transition: .4s;
+  transition: 0.4s;
 }
 
 nav a:hover {
@@ -129,24 +132,32 @@ footer {
   margin-top: 4rem;
   padding: 2rem 1rem 1.5rem 1rem;
   color: var(--text-light);
-  font-size: .9rem;
+  font-size: 0.9rem;
   text-align: center;
   border-top: 1px solid var(--border);
 }
 
 /* Format headers */
 h1 {
-  font-size: calc(var(--base-fontsize) * var(--header-scale) * var(--header-scale) * var(--header-scale) * var(--header-scale));
+  font-size: calc(
+    var(--base-fontsize) * var(--header-scale) * var(--header-scale) *
+      var(--header-scale) * var(--header-scale)
+  );
   margin-top: calc(var(--line-height) * 1.5rem);
 }
 
 h2 {
-  font-size: calc(var(--base-fontsize) * var(--header-scale) * var(--header-scale) * var(--header-scale));
+  font-size: calc(
+    var(--base-fontsize) * var(--header-scale) * var(--header-scale) *
+      var(--header-scale)
+  );
   margin-top: calc(var(--line-height) * 1.5rem);
 }
 
 h3 {
-  font-size: calc(var(--base-fontsize) * var(--header-scale) * var(--header-scale));
+  font-size: calc(
+    var(--base-fontsize) * var(--header-scale) * var(--header-scale)
+  );
   margin-top: calc(var(--line-height) * 1.5rem);
 }
 
@@ -186,9 +197,9 @@ input[type="button"] {
   background: var(--accent);
   font-size: 1rem;
   color: var(--bg);
-  padding: .7rem .9rem;
-  margin: .5rem 0;
-  transition: .4s;
+  padding: 0.7rem 0.9rem;
+  margin: 0.5rem 0;
+  transition: 0.4s;
 }
 
 a button[disabled],
@@ -201,7 +212,7 @@ input[type="checkbox"][disabled],
 input[type="radio"][disabled],
 select[disabled] {
   cursor: default;
-  opacity: .5;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
@@ -234,8 +245,8 @@ input[type="button"]:enabled:hover,
 input[type="checkbox"]:focus,
 input[type="checkbox"]:enabled:hover,
 input[type="radio"]:focus,
-input[type="radio"]:enabled:hover{
-  opacity: .8;
+input[type="radio"]:enabled:hover {
+  opacity: 0.8;
   cursor: pointer;
 }
 
@@ -250,19 +261,19 @@ details {
 summary {
   cursor: pointer;
   font-weight: bold;
-  padding: .6rem 1rem;
+  padding: 0.6rem 1rem;
 }
 
 details[open] {
-  padding: .6rem 1rem .75rem 1rem;
+  padding: 0.6rem 1rem 0.75rem 1rem;
 }
 
 details[open] summary {
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
   padding: 0;
 }
 
-details[open]>*:last-child {
+details[open] > *:last-child {
   margin-bottom: 0;
 }
 
@@ -277,7 +288,7 @@ td,
 th {
   border: 1px solid var(--border);
   text-align: left;
-  padding: .5rem;
+  padding: 0.5rem;
 }
 
 th {
@@ -292,7 +303,7 @@ tr:nth-child(even) {
 
 table caption {
   font-weight: bold;
-  margin-bottom: .5rem;
+  margin-bottom: 0.5rem;
 }
 
 /* Lists */
@@ -307,8 +318,8 @@ select,
 input {
   font-size: inherit;
   font-family: inherit;
-  padding: .5rem;
-  margin-bottom: .5rem;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
   color: var(--text);
   background: var(--bg);
   border: 1px solid var(--border);
@@ -323,15 +334,10 @@ input {
 
 /* Add arrow to  */
 select {
-  background-image:
-    linear-gradient(45deg, transparent 49%, var(--text) 51%),
+  background-image: linear-gradient(45deg, transparent 49%, var(--text) 51%),
     linear-gradient(135deg, var(--text) 51%, transparent 49%);
-  background-position:
-    calc(100% - 20px),
-    calc(100% - 15px);
-  background-size:
-    5px 5px,
-    5px 5px;
+  background-position: calc(100% - 20px), calc(100% - 15px);
+  background-size: 5px 5px, 5px 5px;
   background-repeat: no-repeat;
 }
 
@@ -340,11 +346,13 @@ select[multiple] {
 }
 
 /* checkbox and radio button style */
-input[type="checkbox"], input[type="radio"]{
+input[type="checkbox"],
+input[type="radio"] {
   vertical-align: bottom;
   position: relative;
 }
-input[type="radio"]{
+
+input[type="radio"] {
   border-radius: 100%;
 }
 
@@ -355,7 +363,7 @@ input[type="radio"]:checked {
 
 input[type="checkbox"]:checked::after {
   /* Creates a rectangle with colored right and bottom borders which is rotated to look like a check mark */
-  content: ' ';
+  content: " ";
   width: 0.1em;
   height: 0.25em;
   border-radius: 0;
@@ -370,9 +378,9 @@ input[type="checkbox"]:checked::after {
 }
 input[type="radio"]:checked::after {
   /* creates a colored circle for the checked radio button  */
-  content: ' ';
-  width: .25em;
-  height: .25em;
+  content: " ";
+  width: 0.25em;
+  height: 0.25em;
   border-radius: 100%;
   position: absolute;
   top: 0.125em;
@@ -383,7 +391,7 @@ input[type="radio"]:checked::after {
 
 /* Make the textarea wider than other inputs */
 textarea {
-  width: 80%
+  width: 80%;
 }
 
 /* Makes input fields wider on smaller screens */
@@ -396,7 +404,8 @@ textarea {
 }
 
 /* Ensures the checkbox and radio inputs do not have a set width like other input fields */
-input[type="checkbox"], input[type="radio"]{
+input[type="checkbox"],
+input[type="radio"] {
   width: auto;
 }
 
@@ -426,7 +435,8 @@ mark {
   background: var(--marked);
 }
 
-main img, main video {
+main img,
+main video {
   max-width: 100%;
   height: auto;
   border-radius: 5px;
@@ -437,7 +447,7 @@ figure {
 }
 
 figcaption {
-  font-size: .9rem;
+  font-size: 0.9rem;
   color: var(--text-light);
   text-align: center;
   margin-bottom: 1rem;
@@ -445,9 +455,9 @@ figcaption {
 
 blockquote {
   margin: 2rem 0 2rem 2rem;
-  padding: .4rem .8rem;
-  border-left: .35rem solid var(--accent);
-  opacity: .8;
+  padding: 0.4rem 0.8rem;
+  border-left: 0.35rem solid var(--accent);
+  opacity: 0.8;
   font-style: italic;
 }
 
@@ -473,7 +483,7 @@ kbd {
   border: 1px solid var(--preformatted);
   border-bottom: 3px solid var(--preformatted);
   border-radius: 5px;
-  padding: .1rem;
+  padding: 0.1rem;
 }
 
 pre {


### PR DESCRIPTION
This pull request fixes linting consistency in `simple.css`. The file was auto fixed using [prettier](https://prettier.io/) and  [stylelint](https://stylelint.io/).
- Adds missing closing semicolon
- Prefer single quotes over double quotes
- Keep line length under 80
- Prefer lower case for hex colors
- Prefer new line for multiple selectors 
- Include leading 0 in decimal values

A GitHub action could also be setup to prevent linting errors from being introduced in the future.