### PR TITLE
Center the whole content inside figures, not just the caption

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -431,12 +431,12 @@ main video {
 
 figure {
   margin: 0;
+  text-align: center;
 }
 
 figcaption {
   font-size: 0.9rem;
   color: var(--text-light);
-  text-align: center;
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
This will ensure images and captions are aligned when the image is smaller than the container.

| Example |
| --- |
| **Before:** |
| <img width="633" alt="Screenshot 2022-01-20 at 11 59 01" src="https://user-images.githubusercontent.com/9027541/150326109-7d437859-29b9-489e-9729-bad5d26baadd.png"> |
| **After:** |
| <img width="631" alt="Screenshot 2022-01-20 at 11 58 22" src="https://user-images.githubusercontent.com/9027541/150325982-ca0101a2-8f88-4615-b10a-2adf6fc7cd17.png"> |
