### PR TITLE
aligned role=button closer to button

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -158,6 +158,17 @@ a:hover {
   text-decoration: none;
 }
 
+/* Ensures links with role=button align with button styles/behavior. */
+[role="button"] {
+  text-decoration: none;
+  display: inline-block;
+  line-height: normal;
+}
+
+[role="button"]:visited {
+  color: var(--bg);
+}
+
 button,
 [role="button"],
 input[type="submit"],


### PR DESCRIPTION
looks like there was a few issues with `<a href='...' role='button'>`. hopefully this helps.

continuation of: #46 #47
hopefully this helps resolve: #59
related: #10 #41

### Before
<img width="426" alt="Screen Shot 2022-02-17 at 12 04 14 PM" src="https://user-images.githubusercontent.com/4173104/154543459-bf6ae22b-5c9a-4de5-af08-58c38ecc614a.png">

### After
<img width="426" alt="Screen Shot 2022-02-17 at 12 04 07 PM" src="https://user-images.githubusercontent.com/4173104/154543464-27690e5d-b34b-4b8e-bf47-b6eb6813a06a.png">

@kevquirk let me know what you think. if you accept would you like a PR to update https://simplecss.org/demo#links--buttons?