### PR TITLE
Add fix for last-child items in a `nav`

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -238,6 +238,10 @@ nav a:hover {
   border-color: var(--accent);
 }
 
+nav a:last-child {
+  margin-right: 0;
+}
+
 /* Reduce nav side on mobile */
 @media only screen and (max-width: 750px) {
   nav a {


### PR DESCRIPTION
The `nav` items will have a margin applied to them to adjust for spacing, but fail to clear the margin on the last item, pushing a wide menu off by ~1em.

This removes it.