### PR TITLE
Remove duplicate properties

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -180,7 +180,6 @@ input[type="button"][disabled],
 input[type="checkbox"][disabled],
 input[type="radio"][disabled],
 select[disabled] {
-  cursor: default;
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -503,7 +502,6 @@ pre {
   padding: 1rem 1.4rem;
   max-width: 100%;
   overflow: auto;
-  overflow-x: auto;
   color: var(--preformatted);
   background: var(--accent-bg);
   border: 1px solid var(--border);

--- a/simple.css
+++ b/simple.css
@@ -222,6 +222,27 @@ nav {
   padding: 1rem 0 0 0;
 }
 
+/* Use flexbox to allow items to wrap, as needed */
+nav ul,
+nav ol
+{
+  align-content:   space-around;
+  align-items:     center;
+  display:         flex;
+  flex-direction:  row;
+  justify-content: center;
+  list-style-type: none;
+  margin:          0;
+  padding:         0;
+}
+
+/* List items are inline elements, make them behave more like blocks */
+nav ul li,
+nav ol li
+{
+  display: inline-block;
+}
+
 nav a,
 nav a:visited {
   margin: 0 1rem 1rem 0;


### PR DESCRIPTION
Just some more simple fixes. Found mostly by my editor:

  * Disabled elements: remove `cursor: default` as the property `cursor: not-allowed` is defined right after it.
  * `pre` blocks had `overflow: auto` and `overflow-x: auto`. Only one is needed. I erred on the side of caution and chose the more encompassing option.

Most of these were presenting as expected, so no visual changes, however bytes are bytes. Especially when they're duplicate bytes.