### PR TITLE
Increase left and right padding for 'kbd' element

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -475,7 +475,7 @@ kbd {
   border: 1px solid var(--preformatted);
   border-bottom: 3px solid var(--preformatted);
   border-radius: 5px;
-  padding: 0.1rem;
+  padding: 0.1rem 0.4rem;
 }
 
 pre {


### PR DESCRIPTION
The `kbd` element produces really thin 'keys'. Keys look better when the left and right padding is increased just a little.