### PR TITLE
Fixes Table Overflow

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -305,8 +305,10 @@ details[open] > *:last-child {
 /* Format tables */
 table {
   border-collapse: collapse;
-  width: 100%;
+  display: block;
+  overflow: auto;
   margin: 1.5rem 0;
+  width: 100%;
 }
 
 td,

--- a/simple.css
+++ b/simple.css
@@ -306,8 +306,8 @@ details[open] > *:last-child {
 table {
   border-collapse: collapse;
   display: block;
-  overflow: auto;
   margin: 1.5rem 0;
+  overflow: auto;
   width: 100%;
 }
 


### PR DESCRIPTION
Tables need to have overflow and displays set in order to prevent the tr tags from forcing expansion.

Here're before and after shots:

## Before

![slc is_posts_randomness_(iPhone SE)](https://user-images.githubusercontent.com/25377399/163827705-dbacaee8-d7ed-4a8f-add1-6a761ce0ec64.png)

## After

![slc is_posts_randomness_(iPhone SE) (1)](https://user-images.githubusercontent.com/25377399/163827718-2ea7c0f3-19ba-4544-87f9-00489ae9aa6c.png)

I believe this is the most clean solution.