### PR TITLE
Section boundaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
 					<li><a href="#text__hr">Horizontal rules</a></li>
 					<li><a href="#text__tables">Tabular data</a></li>
 					<li><a href="#text__code">Code</a></li>
+					<li><a href="#text__sections">Sections</a></li>
 					<li><a href="#text__inline">Inline elements</a></li>
 					<li><a href="#text__comments">HTML Comments</a></li>
 				</ul>
@@ -651,6 +652,23 @@
 				<footer>
 					<p><a href="#top">[Top]</a></p>
 				</footer>
+			</article>
+			<article id="text__sections">
+				<header>
+					<h2>Text Sections</h2>
+				</header>
+				<main>
+					<p>Leading Content</p>
+					<section>
+						<p>Test section 1</p>
+					</section>
+					<section>
+						<p>Test section 2</p>
+					</section>
+					<section>
+						<p>Test section 3</p>
+					</section>
+				</main>
 			</article>
 			<article id="text__inline">
 				<header>

--- a/index.html
+++ b/index.html
@@ -657,18 +657,18 @@
 				<header>
 					<h2>Text Sections</h2>
 				</header>
-				<main>
-					<p>Leading Content</p>
-					<section>
-						<p>Test section 1</p>
-					</section>
-					<section>
-						<p>Test section 2</p>
-					</section>
-					<section>
-						<p>Test section 3</p>
-					</section>
-				</main>
+				<section>
+					<h3>Header 1</h3>
+					<p>Test section 1</p>
+				</section>
+				<section>
+					<h3>Header 2</h3>
+					<p>Test section 2</p>
+				</section>
+				<section>
+					<h3>Header 3</h3>
+					<p>Test section 3</p>
+				</section>
 			</article>
 			<article id="text__inline">
 				<header>

--- a/simple.css
+++ b/simple.css
@@ -332,6 +332,18 @@ section {
   margin: 3rem 0;
 }
 
+/* Don't double separators when chaining sections */
+section + section,
+section:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+section:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
 summary {
   cursor: pointer;
   font-weight: bold;


### PR DESCRIPTION
Current section boundary behavior is awkward and not in the testing page. This PR fixes that.

## Changes

- Adds sections to the test page
- Modifies section boundary behavior
  - Sections at the start of a container have no top boundary
  - Sections at the end of a container have no bottom boundary
  - Sections next to each other only share one border
  - Ensures sections still exhibit old behavior when placed inline with non-sectioned HTML
- Resolves #105 