### PR TITLE
Added Pure CSS Image Loader

### DIFF
--- a/simple-v1.css
+++ b/simple-v1.css
@@ -47,6 +47,9 @@
   img,
   video {
     opacity: 0.6;
+     animation: none; 
+  background-color: black;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.0' viewBox='0 0 128 128' %3E%3Cg%3E%3Cpath d='M64 128A64 64 0 0 1 18.34 19.16L21.16 22a60 60 0 1 0 52.8-17.17l.62-3.95A64 64 0 0 1 64 128z' fill='white'/%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 64 64' to='360 64 64' dur='1000ms' repeatCount='indefinite'%3E%3C/animateTransform%3E%3C/g%3E%3C/svg%3E");
   }
 }
 
@@ -445,6 +448,29 @@ main video {
   max-width: 100%;
   height: auto;
   border-radius: 5px;
+  position: relative;
+  display: block;
+  width: 100%;
+  height: auto;
+  background-color: hsl(220, 20%, 90%);
+  /* Make background pulse so it looks kinda load-y */
+  animation: loading 0.8s infinite alternate;
+  
+  /* Loading Image (can used a normal url / SVG if prefered) */ 
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns:svg='http://www.w3.org/2000/svg' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' version='1.0' viewBox='0 0 128 128' %3E%3Cg%3E%3Cpath d='M64 128A64 64 0 0 1 18.34 19.16L21.16 22a60 60 0 1 0 52.8-17.17l.62-3.95A64 64 0 0 1 64 128z' fill='%23404040'/%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 64 64' to='360 64 64' dur='1000ms' repeatCount='indefinite'%3E%3C/animateTransform%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 4rem;
+}
+
+
+
+
+
+ @keyframes loading {
+  to {
+    background-color: hsl(220, 10%, 75%);
+  }
 }
 
 figure {


### PR DESCRIPTION
Added a pure CSS image loader. You can view a demo of this in usage in this repo here! [CSS-Image-Loader: Add a image loader & image load error (without adding an HTML element or using JS).](https://github.com/MarketingPipeline/CSS-Image-Loader)

The ::after was NOT added since it is not supported for web-kit devices. 

Any credit for this etc would be appreciated - tho is not required. 

Note > I did not add it to img tho I would advise applying it to the <code>img</code> tag as well instead of just <code>main img</code>

Cheers! :+1: 