### PR TITLE
Fix summary margins when using nested details

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -356,11 +356,11 @@ summary {
   word-break: break-all;
 }
 
-details[open] summary + * {
+details[open] > summary + * {
   margin-top: 0;
 }
 
-details[open] summary {
+details[open] > summary {
   margin-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
Bottom margin on summary of open details should only be applied to the summary that is a direct child, not to more deeply nested summary tags that might not be open. 

Otherwise, nested details tags will look weird when they are not open, because the bottom margin of the summary would be larger than the top margin.