### PR TITLE
Change dl grid-template-columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,10 +154,15 @@
 					<h2>Lists</h2>
 				</header>
 				
-					<h3>Definition list</h3>
+					<h3>Description list</h3>
 					<dl>
-						<dt>Definition List Title</dt>
-						<dd>This is a definition list division.</dd>
+						<dt>Description Title</dt>
+						<dd>This is a description division.</dd>
+						<dd>This is another description division.</dd>
+						<dt>Description Title</dt>
+						<dt>This is a second term</dt>
+						<dt>This is a third term</dt>
+						<dd>Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptas, modi iure! Incidunt, dolorum sit? Dolorum cumque omnis accusantium doloremque nihil est perferendis voluptas delectus, quis aperiam blanditiis deleniti modi at. Lorem ipsum dolor sit amet consectetur adipisicing elit. Vel, perspiciatis, vero accusantium sed dicta exercitationem iure praesentium nobis esse ullam sunt cum blanditiis! Neque similique corporis animi voluptatibus et modi.</dd>
 					</dl>
 					<h3>Ordered List</h3>
 					<ol type="1">

--- a/simple.css
+++ b/simple.css
@@ -549,7 +549,7 @@ cite {
 
 dl {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: 1fr 1fr;
 }
 
 dl dt {

--- a/simple.css
+++ b/simple.css
@@ -547,18 +547,8 @@ cite {
   font-style: normal;
 }
 
-dl {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-}
-
-dl dt {
-  grid-column-start: 1;
-  color: var(--text-light);
-}
-
-dl dd {
-  grid-column-start: 2;
+dt {
+    color: var(--text-light);
 }
 
 /* Use mono font for code elements */


### PR DESCRIPTION
Added a change because the dt column in a document list ends up taking most of the space, instead of taking up half the space. This happened when I added word-break and overflow-wrap to one of the dd elements. The dt column then took more than half of the available space and forced a word-break even though there was enough space.

Or maybe write `grid-template-columns: auto` also seems to work.

If u want more info, I'm happy to share.
- Denis