### PR TITLE
Change abbr css

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -218,9 +218,11 @@ input[type="range"] {
   padding: 0;
 }
 
-/* Set the cursor to '?' while hovering over an abbreviation */
-abbr {
+/* Set the cursor to '?' on an abbreviation and style the abbreviation to show that there is more information underneath */
+abbr[title] {
   cursor: help;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
 }
 
 button:focus,


### PR DESCRIPTION
In the [MDN Docs for abbr](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr?retiredLocale=de) the title attribute is not always present and it is recommended to explain the abbreviation in plain text the first time the abbreviation is used. 

Considering this I think it makes little sense to change the cursor on hover because this could lead to confusion as nothing happens upon hovering. Whenever there is a title attribute then changing the cursor makes sense. To make the abbreviation stand out from normal text I think some form of styling is also welcome to communicate interactivity to the user.

A different styling would be to add content like `(?)` after it, but I think this doesn't speak to the simpleCSS design principle and the dotted underline also seems to match what some [other browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr?retiredLocale=de#default_styling) do by standard.

I didn't use the `text-decoration` shorthand because somehow Safari doesn't display the styling. Maybe it's not only unique to my machine, so you'd have to test this.