### PR TITLE
Preventing sup/sub from affecting line-height

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -649,6 +649,18 @@ dialog::backdrop {
   }
 }
 
+/* Superscript & Subscript */
+/* Prevent scripts from affecting line-height. */
+sup, sub {
+  vertical-align: baseline;
+  position: relative;
+  top: -0.4em;
+}
+
+sub { 
+  top: 0.3em; 
+}
+
 /* Classes for notices */
 .notice {
   background: var(--accent-bg);


### PR DESCRIPTION
👋🏼  I noticed `sup` and `sub` tags were (very) subtly affecting line-heights and added a fix ([credit](https://css-tricks.com/snippets/css/prevent-superscripts-and-subscripts-from-affecting-line-height/)).

| Before | After  |
| ------ | ------ |
| <img width="812" alt="Screenshot 2023-06-21 at 9 36 45 PM" src="https://github.com/kevquirk/simple.css/assets/4173104/f0c71046-02d5-4731-8a75-2942a77e0090"> | <img width="812" alt="Screenshot 2023-06-21 at 9 36 30 PM" src="https://github.com/kevquirk/simple.css/assets/4173104/6eb66e86-3540-4831-8554-5bc1a00ddeb3"> |
