### PR TITLE
Fixes link color inside of highlights

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -178,6 +178,10 @@ a:hover {
   text-decoration: none;
 }
 
+mark a {
+  color: black;
+}
+
 button,
 .button,
 a.button, /* extra specificity to override a */


### PR DESCRIPTION
👋🏼 Link colors inside of highlights seems a bit hard to read to me.

| | Before | After |
|--------|--------|--------|
| Light | <img width="150" alt="Screenshot 2023-06-22 at 7 39 10 PM" src="https://github.com/kevquirk/simple.css/assets/4173104/c4d24faf-e290-4e64-8c33-3248b6af1fdd"> | <img width="150" alt="Screenshot 2023-06-22 at 7 39 28 PM" src="https://github.com/kevquirk/simple.css/assets/4173104/ba9a59f6-4277-4c20-8269-83a24b398b33"> |
| Dark | <img width="150" alt="Screenshot 2023-06-22 at 7 39 02 PM" src="https://github.com/kevquirk/simple.css/assets/4173104/09721206-c4a0-41e3-8c9a-dbdcfda873e0"> | <img width="150" alt="Screenshot 2023-06-22 at 7 39 35 PM" src="https://github.com/kevquirk/simple.css/assets/4173104/8becdd84-bd83-48a8-8c11-8ee760b5607a"> |