### PR TITLE
Add NPM publish workflow. Fixes #150

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,18 @@
+name: NPM Publish
+
+on:
+ release:
+   types: [created]
+jobs:
+ build:
+   runs-on: ubuntu-latest
+   steps:
+     - uses: actions/checkout@v3
+     - uses: actions/setup-node@v3
+       with:
+         node-version: '18.x'
+         registry-url: 'https://registry.npmjs.org'
+     - run: npm install -g npm
+     - run: npm publish --access public
+       env:
+         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Requires the NPM token to be a secret with the key "NPM_TOKEN".