### PR TITLE
Same styles for buttons and inputs

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -185,15 +185,9 @@ input[type="submit"],
 input[type="reset"],
 input[type="button"],
 label[type="button"] {
-  border: none;
-  border-radius: var(--standard-border-radius);
   background-color: var(--accent);
-  font-size: 1rem;
   color: var(--bg);
-  padding: 0.7rem 0.9rem;
-  margin: 0.5rem 0;
   text-decoration: none;
-  font-family: inherit;
   line-height: normal;
 }
 
@@ -409,7 +403,9 @@ table caption {
 /* Format forms */
 textarea,
 select,
-input {
+input,
+button,
+.button {
   font-size: inherit;
   font-family: inherit;
   padding: 0.5rem;

--- a/simple.css
+++ b/simple.css
@@ -185,7 +185,7 @@ input[type="submit"],
 input[type="reset"],
 input[type="button"],
 label[type="button"] {
-  border-color: var(--accent);
+  border: 1px solid var(--accent);
   background-color: var(--accent);
   color: var(--bg);
   padding: 0.5rem 0.9rem;
@@ -200,7 +200,8 @@ select:disabled,
 button[disabled] {
   cursor: not-allowed;
   background-color: var(--disabled);
-  color: var(--text-light)
+  border-color: var(--disabled);
+  color: var(--text-light);
 }
 
 input[type="range"] {
@@ -412,13 +413,17 @@ button,
   font-family: inherit;
   padding: 0.5rem;
   margin-bottom: 0.5rem;
-  color: var(--text);
-  background-color: var(--bg);
-  border: 1px solid var(--border);
   border-radius: var(--standard-border-radius);
   box-shadow: none;
   max-width: 100%;
   display: inline-block;
+}
+textarea,
+select,
+input {
+  color: var(--text);
+  background-color: var(--bg);
+  border: 1px solid var(--border);
 }
 label {
   display: block;

--- a/simple.css
+++ b/simple.css
@@ -185,8 +185,10 @@ input[type="submit"],
 input[type="reset"],
 input[type="button"],
 label[type="button"] {
+  border-color: var(--accent);
   background-color: var(--accent);
   color: var(--bg);
+  padding: 0.5rem 0.9rem;
   text-decoration: none;
   line-height: normal;
 }


### PR DESCRIPTION
When you add an `input[type=text]` next to an `input[type=submit]`, they are not aligned vertically.
This PR uses the same styles for inputs and buttons to fix this.

Before: 
![image](https://github.com/kevquirk/simple.css/assets/4655583/0c883be6-9d69-414d-9bbc-f32a0eb41b8c)

After: 
![image](https://github.com/kevquirk/simple.css/assets/4655583/bb20367e-20c6-41ab-a5da-ea2a9489937c)

I tested this PR with Firefox on Windows.