### PR TITLE
Have notice class match variable customization for border-radius

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -685,7 +685,7 @@ sub {
 .notice {
   background: var(--accent-bg);
   border: 2px solid var(--border);
-  border-radius: 5px;
+  border-radius: var(--standard-border-radius);
   padding: 1.5rem;
   margin: 2rem 0;
 }


### PR DESCRIPTION
Proposing class ".notice" remains consistent with root/backdrop global variable for --standard-border-radius