### PR TITLE
Suggestion: Reduce some vertical space on mobile

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -178,6 +178,23 @@ h3 {
   }
 }
 
+/* Reduce some vertical space on mobile */
+@media only screen and (max-width: 720px) {
+  body > header {
+    padding-bottom: .5rem;
+  }
+  section:first-child {
+    margin-top: 1rem;
+  }
+  section:last-child {
+    margin-bottom: 2rem;
+  }
+  body > footer {
+    margin-top: 1rem;
+    padding-top: 1rem;
+  }
+}
+
 /* Format links & buttons */
 a,
 a:visited {


### PR DESCRIPTION
Thank you for this stylesheet, I think it's great!

This is of course subjective so feel free to disagree, but I find there is lots of vertical space on mobile, especially at the beginning of the page, that causes the page's content to appear lower on the screen. I think that could be reduced a bit, so this patch is just a suggestion for that.

### Before (left) & After (right)
![before](https://github.com/kevquirk/simple.css/assets/4613111/837669f1-73ac-4c3b-a218-0eb11583d69f) ![after](https://github.com/kevquirk/simple.css/assets/4613111/23b5b357-1101-406a-9104-c38d95c945dd)

