### PR TITLE
fix (missing) margin collapses for sections

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -359,6 +359,10 @@ section:first-child {
   padding-top: 0;
 }
 
+section + section {
+  margin-top: 0;
+}
+
 section:last-child {
   border-bottom: 0;
   padding-bottom: 0;

--- a/simple.css
+++ b/simple.css
@@ -341,7 +341,9 @@ article, fieldset, dialog {
 }
 
 article h2:first-child,
-section h2:first-child {
+section h2:first-child,
+article h3:first-child,
+section h3:first-child {
   margin-top: 1rem;
 }
 


### PR DESCRIPTION
Fixes margin collapse for adjacent sections. I used a separate `section+section` selector because I don't think `section:first-child` should have no top margin.

Also collapse the margin h3 tags at the start of a section or article. There was already an equivalent rule for h2 so it looked to me like it was forgotten.