### PR TITLE
Aria current tweak

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -289,7 +289,8 @@ header > nav a:visited {
 
 header > nav a:hover,
 header > nav a.current,
-header > nav a[aria-current] {
+header > nav a[aria-current="page"],
+header > nav a[aria-current="true"] {
   border-color: var(--accent);
   color: var(--accent);
   cursor: pointer;

--- a/simple.css
+++ b/simple.css
@@ -289,7 +289,7 @@ header > nav a:visited {
 
 header > nav a:hover,
 header > nav a.current,
-header > nav a[aria-current="page"] {
+header > nav a[aria-current] {
   border-color: var(--accent);
   color: var(--accent);
   cursor: pointer;


### PR DESCRIPTION
I’m building a site with Simple.css and I have a Blog link in the header. From there I have a list of blog posts in the body. If someone clicks on an individual blog article, I'd still like to highlight "Blog" as it’s the current section. But it isn’t the current page. Best I can see from a bit of searching, the way to mark this up is to use `aria-current="true"`. This indicates Blog as being the current item in a set, without declaring that it’s the current page.

My suggestion is to add support for `aria-current="true"`. That’s helpful for more general applications of `aria-current`. That said, if there’s a better way to indicate "current section" I'm all ears.