### PR TITLE
Remove unnecessary ::backdrop selector from :root 

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -669,6 +669,7 @@ progress:indeterminate::-moz-progress-bar {
 }
 
 dialog {
+  background-color: var(--bg);
   max-width: 40rem;
   margin: auto;
 }

--- a/simple.css
+++ b/simple.css
@@ -1,6 +1,5 @@
 /* Global variables. */
-:root,
-::backdrop {
+:root {
   /* Set sans-serif & mono fonts */
   --sans-font: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir,
     "Nimbus Sans L", Roboto, "Noto Sans", "Segoe UI", Arial, Helvetica,
@@ -25,8 +24,7 @@
 
 /* Dark theme */
 @media (prefers-color-scheme: dark) {
-  :root,
-  ::backdrop {
+  :root {
     color-scheme: dark;
     --bg: #212121;
     --accent-bg: #2b2b2b;


### PR DESCRIPTION
Fixes #214 

Using variables specified in `:root` still works, because `::backdrop` inherits from `<dialog>` which inherits from `:root`.

Also fixed an issue in Firefox where the background of a dialog element would be gray instead of white in light mode.