### PR TITLE
Add --border-width variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,9 @@
 					<li><a href="#forms__action">Action buttons</a></li>
 				</ul>
 			</li>
+			<li>
+				<a href="#classes">Classes</a>
+			</li>
 		</ul>
 	</nav>
 	<main>
@@ -112,7 +115,6 @@
 						paragraph consists of one or more sentences. Though not required by the syntax of any
 						language, paragraphs are usually an expected part of formal writing, used to organize longer
 						prose.</p>
-				
 				<footer>
 					<p><a href="#top">[Top]</a></p>
 				</footer>
@@ -1098,6 +1100,12 @@
 				</fieldset>
 				<p><a href="#top">[Top]</a></p>
 			</form>
+		</section>
+		<section id="classes">
+			<header>
+				<h2>Classes</h2>
+			</header>
+			<p class="notice">This is a paragraph element with the <code>.notice</code> class.</p>
 		</section>
 	</main>
 	<footer>

--- a/simple.css
+++ b/simple.css
@@ -6,6 +6,7 @@
     "Helvetica Neue", sans-serif;
   --mono-font: Consolas, Menlo, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
   --standard-border-radius: 5px;
+  --border-width: 1px;
 
   /* Default (light) theme */
   --bg: #fff;
@@ -82,7 +83,7 @@ body > * {
 /* Make the header bg full width, but the content inline with body */
 body > header {
   background-color: var(--accent-bg);
-  border-bottom: 1px solid var(--border);
+  border-bottom: var(--border-width) solid var(--border);
   text-align: center;
   padding: 0 0.5rem 2rem 0.5rem;
   grid-column: 1 / -1;
@@ -113,7 +114,7 @@ body > footer {
   color: var(--text-light);
   font-size: 0.9rem;
   text-align: center;
-  border-top: 1px solid var(--border);
+  border-top: var(--border-width) solid var(--border);
 }
 
 /* Format headers */
@@ -194,7 +195,7 @@ a.button, /* extra specificity to override a */
 input[type="submit"],
 input[type="reset"],
 input[type="button"] {
-  border: 1px solid var(--accent);
+  border: var(--border-width) solid var(--accent);
   background-color: var(--accent);
   color: var(--accent-text);
   padding: 0.5rem 0.9rem;
@@ -275,7 +276,7 @@ header nav ol li {
 header nav a,
 header nav a:visited {
   margin: 0 0.5rem 1rem 0.5rem;
-  border: 1px solid var(--border);
+  border: var(--border-width) solid var(--border);
   border-radius: var(--standard-border-radius);
   color: var(--text);
   display: inline-block;
@@ -305,7 +306,7 @@ header nav a[aria-current="true"] {
 /* Consolidate box styling */
 aside, details, pre, progress {
   background-color: var(--accent-bg);
-  border: 1px solid var(--border);
+  border: var(--border-width) solid var(--border);
   border-radius: var(--standard-border-radius);
   margin-bottom: 1rem;
 }
@@ -331,7 +332,7 @@ aside {
 }
 
 article, fieldset, dialog {
-  border: 1px solid var(--border);
+  border: var(--border-width) solid var(--border);
   padding: 1rem;
   border-radius: var(--standard-border-radius);
   margin-bottom: 1rem;
@@ -345,8 +346,8 @@ section h3:first-child {
 }
 
 section {
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
+  border-top: var(--border-width) solid var(--border);
+  border-bottom: var(--border-width) solid var(--border);
   padding: 2rem 1rem;
   margin: 3rem 0;
 }
@@ -404,7 +405,7 @@ figure > table {
 
 td,
 th {
-  border: 1px solid var(--border);
+  border: var(--border-width) solid var(--border);
   text-align: start;
   padding: 0.5rem;
 }
@@ -444,7 +445,7 @@ select,
 input {
   color: var(--text);
   background-color: var(--bg);
-  border: 1px solid var(--border);
+  border: var(--border-width) solid var(--border);
 }
 label {
   display: block;
@@ -539,7 +540,7 @@ input[type="file"] {
 /* Misc body elements */
 hr {
   border: none;
-  height: 1px;
+  height: var(--border-width);
   background: var(--border);
   margin: 1rem auto;
 }
@@ -613,7 +614,7 @@ samp {
 
 kbd {
   color: var(--preformatted);
-  border: 1px solid var(--preformatted);
+  border: var(--border-width) solid var(--preformatted);
   border-bottom: 3px solid var(--preformatted);
   border-radius: var(--standard-border-radius);
   padding: 0.1rem 0.4rem;
@@ -701,7 +702,7 @@ sub {
 /* Classes for notices */
 .notice {
   background: var(--accent-bg);
-  border: 2px solid var(--border);
+  border: var(--border-width) solid var(--border);
   border-radius: var(--standard-border-radius);
   padding: 1.5rem;
   margin: 2rem 0;
@@ -740,10 +741,10 @@ sub {
     orphans: 3;
   }
   hr {
-    border-top: 1px solid var(--border);
+    border-top: var(--border-width) solid var(--border);
   }
   mark {
-    border: 1px solid var(--border);
+    border: var(--border-width) solid var(--border);
   }
   pre, table, figure, img, svg {
     break-inside: avoid;


### PR DESCRIPTION
Added a variable to control border width and updated every element with a 1px border size to use the variable instead, as well as `hr` height and the `.notice` class. The `.notice` class previously had a border width of 2px.

Also added the `.notice` class to the test page under a new "Classes" section.

Fixes #236 