### PR TITLE
Add styling for input range selector

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -215,6 +215,25 @@ button[disabled] {
 
 input[type="range"] {
   padding: 0;
+  --size: 1.5rem;
+  --radius: calc(var(--standard-border-radius) - 1px);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  height: var(--size);
+  width: var(--size);
+  background-color: var(--accent);
+  border-radius: var(--radius);
+}
+
+input[type="range"]::-moz-range-thumb {
+  appearance: none;
+  height: var(--size);
+  width: var(--size);
+  background-color: var(--accent);
+  border-radius: var(--radius);
+  border: none;
 }
 
 /* Set the cursor to '?' on an abbreviation and style the abbreviation to show that there is more information underneath */


### PR DESCRIPTION
@bas080 mentioned the lack of styling on the range element in https://github.com/kevquirk/simple.css-site/issues/31

I decided to take a look at adding styling, but after going through the effort of doing so, I'm no longer convinced it's worth it. I'm looking for further input on whether we should include this, considering the extra 19 lines we'd be adding and my opinion that this is a niche element.

The reason I have doubts now is because there isn't a DRY approach to styling browser shadow elements. Browsers drop combined selectors for these, which means writing the selector like this won't work:

```css
input[type="range"]::-webkit-slider-thumb,
input[type="range"]::-moz-range-thumb {}
```

Same goes for CSS nesting. We're forced to write explicit selectors with duplicated properties to apply the styling.

We do include support for progress bars though, with similar styling challenges: https://github.com/kevquirk/simple.css/blob/86406997a8003951c008851633482b15a83c7f93/simple.css#L638-L668