### PR TITLE
Change radio:checked::after size to relative value (to 2em from 32px)

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -433,7 +433,7 @@ button,
 .button {
   font-size: inherit;
   font-family: inherit;
-  padding: 0.4375em;
+  padding: 0.5em;
   margin-bottom: 0.5rem;
   border-radius: var(--standard-border-radius);
   box-shadow: none;

--- a/simple.css
+++ b/simple.css
@@ -203,7 +203,7 @@ input[type="button"] {
   line-height: normal;
 }
 
-.button[aria-disabled="true"],
+.button[aria-disabled="true"], 
 input:disabled,
 textarea:disabled,
 select:disabled,
@@ -433,7 +433,7 @@ button,
 .button {
   font-size: inherit;
   font-family: inherit;
-  padding: 0.5em;
+  padding: 0.4375em;
   margin-bottom: 0.5rem;
   border-radius: var(--standard-border-radius);
   box-shadow: none;
@@ -514,7 +514,7 @@ input[type="radio"]:checked::after {
   top: 0.125em;
   background-color: var(--bg);
   left: 0.125em;
-  font-size: 2em;
+  font-size: 1.75em;
 }
 
 /* Makes input fields wider on smaller screens */
@@ -695,8 +695,8 @@ sup {
   top: -0.4em;
 }
 
-sub {
-  top: 0.3em;
+sub { 
+  top: 0.3em; 
 }
 
 /* Classes for notices */

--- a/simple.css
+++ b/simple.css
@@ -203,7 +203,7 @@ input[type="button"] {
   line-height: normal;
 }
 
-.button[aria-disabled="true"], 
+.button[aria-disabled="true"],
 input:disabled,
 textarea:disabled,
 select:disabled,
@@ -433,7 +433,7 @@ button,
 .button {
   font-size: inherit;
   font-family: inherit;
-  padding: 0.5rem;
+  padding: 0.5em;
   margin-bottom: 0.5rem;
   border-radius: var(--standard-border-radius);
   box-shadow: none;
@@ -514,7 +514,7 @@ input[type="radio"]:checked::after {
   top: 0.125em;
   background-color: var(--bg);
   left: 0.125em;
-  font-size: 32px;
+  font-size: 2em;
 }
 
 /* Makes input fields wider on smaller screens */
@@ -695,8 +695,8 @@ sup {
   top: -0.4em;
 }
 
-sub { 
-  top: 0.3em; 
+sub {
+  top: 0.3em;
 }
 
 /* Classes for notices */

--- a/simple.css
+++ b/simple.css
@@ -492,12 +492,12 @@ input[type="radio"]:checked {
 input[type="checkbox"]:checked::after {
   /* Creates a rectangle with colored right and bottom borders which is rotated to look like a check mark */
   content: " ";
-  width: 0.18em;
-  height: 0.32em;
+  width: 0.2em;
+  height: 0.4em;
   border-radius: 0;
   position: absolute;
-  top: 0.05em;
-  left: 0.17em;
+  top: 0.04em;
+  left: 0.18em;
   background-color: transparent;
   border-right: solid var(--bg) 0.08em;
   border-bottom: solid var(--bg) 0.08em;
@@ -507,14 +507,14 @@ input[type="checkbox"]:checked::after {
 input[type="radio"]:checked::after {
   /* creates a colored circle for the checked radio button  */
   content: " ";
-  width: 0.25em;
-  height: 0.25em;
+  width: 0.3em;
+  height: 0.3em;
   border-radius: 100%;
   position: absolute;
   top: 0.125em;
   background-color: var(--bg);
   left: 0.125em;
-  font-size: 1.75em;
+  font-size: 1.8em;
 }
 
 /* Makes input fields wider on smaller screens */


### PR DESCRIPTION
Hello, I always find it useful.
Thank you for the wonderful CSS library.

I noticed that when I tried to change the size of the radio button slightly, the check mark was misaligned.

I think this is not a common scenario, but it may work if you set the size of the radio button to a relative value.

If you were to write it in index.html, it would be the following sample code,
but I didn't include it in the commit because I didn't want to put a style tag in a simple test page.

```html
<p>Nested <code>label > input with custom font-size</code></p>
<ul style="font-size: 2rem; line-height: 2;">
	<li><label for="radio7"><input id="radio7" name="radio" type="radio" checked="checked">
			Option 1</label></li>
	<li><label for="radio8"><input id="radio8" name="radio" type="radio"> Option 2</label></li>
	<li><label for="radio9"><input id="radio9" name="radio" type="radio"> Option 3</label></li>
</ul>
```
