### PR TITLE
Keep figure captions on the screen while scrolling

### DIFF
--- a/simple.css
+++ b/simple.css
@@ -576,6 +576,8 @@ figure > picture > img {
 }
 
 figcaption {
+  position: sticky;
+  left: 0;
   text-align: center;
   font-size: 0.9rem;
   color: var(--text-light);


### PR DESCRIPTION
Wide figures would have their caption go out of view otherwise.

![2025-05-20 13-23-46](https://github.com/user-attachments/assets/23e653b2-97be-46ae-9cf2-e18a6f84220f)

By the way, thanks for the good laugh I had reading the actual contents of the example table! 😀